### PR TITLE
Fix js error on Firefox for IOS 9

### DIFF
--- a/xui1.4/xui/js/UI/Input.js
+++ b/xui1.4/xui/js/UI/Input.js
@@ -843,7 +843,7 @@ Class("xui.UI.Input", ["xui.UI.Widget","xui.absValue"] ,{
                     //get corret string according to maskTxt
                     var a=[];
                     _.arr.each(maskTxt.split(''),function(o,i){
-                        a.push( (new RegExp('^'+(map[o]?map[o]:'\\'+o)+'$').test(t.charAt(i))) ? t.charAt(i) : maskStr.charAt(i))
+                        a.push( map[o]?(((new RegExp('^'+map[o]+'$')).test(t.charAt(i))) ? t.charAt(i) : maskStr.charAt(i)) : maskStr.charAt(i))
                     });
     
                     //if input visible char

--- a/xui1.4/xui/js/xui.js
+++ b/xui1.4/xui/js/xui.js
@@ -1737,8 +1737,10 @@ new function(){
         if(b.isSafari){
            if(/applewebkit\/4/.test(u))
                 b["safari"+(b.ver=2)]=true;
-           else
+           else if(/version/.test(u))
                 b[v('safari','version/')]=true;
+           else
+                b["safari"]=true;
         }else if(b.isChrome)
             b[v('chrome','chrome/')]=true;
 


### PR DESCRIPTION
ios9 上使用火狐打不开crossui的网页
原因是火狐的UA里面没有version字段,因此在尝试读取version的时候就出错了