### PR TITLE
Fix mask error

### DIFF
--- a/xui1.4/xui/js/UI/Input.js
+++ b/xui1.4/xui/js/UI/Input.js
@@ -843,7 +843,7 @@ Class("xui.UI.Input", ["xui.UI.Widget","xui.absValue"] ,{
                     //get corret string according to maskTxt
                     var a=[];
                     _.arr.each(maskTxt.split(''),function(o,i){
-                        a.push( (new RegExp('^'+(map[o]?map[o]:'\\'+o)+'$').test(t.charAt(i))) ? t.charAt(i) : maskStr.charAt(i))
+                        a.push( map[o]?(((new RegExp('^'+map[o]+'$')).test(t.charAt(i))) ? t.charAt(i) : maskStr.charAt(i)) : maskStr.charAt(i))
                     });
     
                     //if input visible char


### PR DESCRIPTION
当input mask为 SSSSS111, 而input里面有不符合mask的初始值的时候, 点击input, 里面的值会显示错误
原因是当mask是S的时候会使用 ^\S$ 去匹配字符,返回为true